### PR TITLE
Added video forwarder script 

### DIFF
--- a/src/wolf_vision/scripts/video_forwarder.py
+++ b/src/wolf_vision/scripts/video_forwarder.py
@@ -28,7 +28,8 @@ def forwarder(file_name):
         if ret == False:
             break
         
-        final = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+        final = frame
+        #final = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
         writer.write(final)
 
         image_pub.publish(bridge.cv2_to_imgmsg(final, "bgr8"))

--- a/src/wolf_vision/scripts/video_forwarder.py
+++ b/src/wolf_vision/scripts/video_forwarder.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import cv2
+import rospy
+from cv_bridge import CvBridge, CvBridgeError
+from sensor_msgs.msg import Image
+import time
+import sys
+
+def forwarder(file_name):
+    rospy.init_node('camera_forwarder', anonymous=False)
+    rate = rospy.Rate(10)
+
+    video = cv2.VideoCapture(file_name)
+    bridge = CvBridge()
+
+    frame_width = int(video.get(3))
+    frame_height = int(video.get(4))
+   
+    size = (frame_width, frame_height)
+
+    image_pub = rospy.Publisher('wolf_camera1/image_raw', Image, queue_size=10)
+    writer = cv2.VideoWriter('test' + str(time.time()) + '.avi', 
+                         cv2.VideoWriter_fourcc(*'MJPG'),
+                         10, size)
+
+    while not rospy.is_shutdown() and video.isOpened():
+        ret, frame = video.read()
+        if ret == False:
+            break
+        
+        final = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+        writer.write(final)
+
+        image_pub.publish(bridge.cv2_to_imgmsg(final, "bgr8"))
+        rate.sleep()
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: python video_forwarder.py file_name")
+        exit(1)
+    print("Calling forwarder with {} file", sys.argv[1])
+    forwarder(sys.argv[1])
+    


### PR DESCRIPTION
to use a video file to read and send to the image_raw ros node for debugging help.

compare to the [camera_forwarder.py script](https://github.com/ncsurobotics/Seawolf-8-Software/blob/424pooltest/src/wolf_vision/scripts/camera_forwarder.py) for reference.

the VideoCapture method from cv2 supports file input by [just using the video file name ](https://docs.opencv.org/4.5.2/dd/d43/tutorial_py_video_display.html) as the input parameter.

Note: the video file must live in the same directory as this script to run without modifications.

@Namr 